### PR TITLE
Use the default configuration to build library.

### DIFF
--- a/myocamlbuild.ml
+++ b/myocamlbuild.ml
@@ -750,4 +750,4 @@ let () =
   in
   dispatch (
     MyOCamlbuildBase.dispatch_combine
-      [MyOCamlbuildBase.dispatch_default package_default; additional_rules])
+      [MyOCamlbuildBase.dispatch_default conf package_default; additional_rules])

--- a/myocamlbuild.ml
+++ b/myocamlbuild.ml
@@ -732,13 +732,13 @@ let () =
         let osqlite3_cflags =
           let cmd = "pkg-config --cflags sqlite3" in
           match read_lines_from_cmd ~max_lines:1 cmd with
-          | [cflags] -> S (ocamlify ~ocaml_flag:"-ccopt" cflags)
+          | [cflags] when cflags <> "" -> S (ocamlify ~ocaml_flag:"-ccopt" cflags)
           | _ -> failwith "pkg-config failed for cflags"
         in
         let sqlite3_clibs, osqlite3_clibs =
           let cmd = "pkg-config --libs sqlite3" in
           match read_lines_from_cmd ~max_lines:1 cmd with
-          | [libs] ->
+          | [libs] when libs <> "" ->
               S (split_flags libs), S (ocamlify ~ocaml_flag:"-cclib" libs)
           | _ -> failwith "pkg-config failed for libs"
         in


### PR DESCRIPTION
I think the conf is missing.
I think this addresses issue https://github.com/mmottl/sqlite3-ocaml/issues/2