### PR TITLE
Added support for user-defined function errors

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -112,6 +112,19 @@ Test test_stmt
   WorkingDirectory:   test
   PostCommand:        rm t
 
+Executable test_error
+  Path:           test
+  MainIs:         test_error.ml
+  Build$:         flag(tests)
+  Install:        false
+  BuildDepends:   sqlite3
+  CompiledObject: best
+
+Test test_error
+  Run$:               flag(tests)
+  Command:            $test_error
+  WorkingDirectory:   test
+
 #
 
 Document API

--- a/lib/sqlite3.ml
+++ b/lib/sqlite3.ml
@@ -112,12 +112,13 @@ module Data = struct
     | FLOAT of float
     | TEXT of string
     | BLOB of string
+    | ERROR of string
 
   let to_string = function
     | NONE | NULL -> ""
     | INT i -> Int64.to_string i
     | FLOAT f -> string_of_float f
-    | TEXT t | BLOB t -> t
+    | TEXT t | BLOB t | ERROR t -> t
 
   let to_string_debug = function
     | NONE -> "NONE"
@@ -126,6 +127,7 @@ module Data = struct
     | FLOAT f -> sprintf "FLOAT <%f>" f
     | TEXT t -> sprintf "TEXT <%S>" t
     | BLOB b -> sprintf "BLOB <%d>" (String.length b)
+    | ERROR e -> sprintf "ERROR <%S>" e
 end
 
 type header = string

--- a/lib/sqlite3.mli
+++ b/lib/sqlite3.mli
@@ -142,6 +142,7 @@ module Data : sig
     | FLOAT of float
     | TEXT of string
     | BLOB of string
+    | ERROR of string
 
   val to_string : t -> string
   (** [to_string data] converts [data] to a string.  Both [NONE] and

--- a/lib/sqlite3_stubs.c
+++ b/lib/sqlite3_stubs.c
@@ -847,6 +847,8 @@ CAMLprim value caml_sqlite3_bind(value v_stmt, value v_index, value v_data)
                                         String_val(v_field),
                                         caml_string_length(v_field),
                                         SQLITE_TRANSIENT));
+      case 4 :
+        return Val_rc(SQLITE_ERROR);
     }
   }
   return Val_rc(SQLITE_ERROR);
@@ -1022,6 +1024,9 @@ static inline void set_sqlite3_result(sqlite3_context *ctx, value v_res)
       case 3 :
         sqlite3_result_blob(
           ctx, String_val(v), caml_string_length(v), SQLITE_TRANSIENT);
+        break;
+      case 4 :
+        sqlite3_result_error(ctx, String_val(v), caml_string_length(v));
         break;
       default :
         sqlite3_result_error(ctx, "unknown value returned by callback", -1);

--- a/test/test_error.ml
+++ b/test/test_error.ml
@@ -1,0 +1,20 @@
+open Sqlite3
+
+(* Tests our ability to return an error from a user defined function *)
+let _ =
+  let db = db_open "t" in
+  create_fun0 db "MYERROR" (fun () -> Data.ERROR "This function always errors");
+  let res = exec db "SELECT MYERROR();" in
+  match res with
+  | Rc.ERROR -> print_endline (errmsg db)
+  | x -> prerr_endline ("Should have thrown an error: " ^ Rc.to_string x)
+
+(* Insures that we can't bind an error to a query *)
+let _ =
+  let db = db_open "t" in
+  let _ = exec db "CREATE TABLE foo (val text);" in
+  let s = Sqlite3.prepare db "INSERT INTO foo values (?);" in
+  let res = Sqlite3.bind s 1 (Sqlite3.Data.ERROR "Should be impossible") in
+  match res with
+  | Rc.ERROR -> print_endline ("Bind threw an error")
+  | x -> prerr_endline ("Should have thrown an error: " ^ Rc.to_string x)


### PR DESCRIPTION
Basically, I added a new Data type called `ERROR`, which can be used to allow user-defined functions to return errors.  At the moment, there doesn't appear to be a way for these functions to call `sqlite3_result_error`, which is moderately important for returning sane error messages out of a function that needs to return an error.  From what I can tell, the current methodology for returning an error is to have the user-defined function throw an exception.  However, in this case, we just get the message "OCaml callback raised an exception", which doesn't contain much information.