### PR TITLE
Extend brewcheck logic via environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,9 @@ Undefined symbols for architecture ...:
 
   * If you need to change where `pkg-config` will look for the SQLite3
     library, set the `PKG_CONFIG_PATH` environment variable to the new
-    directory.
+    directory. This can be automated by setting the `SQLITE3_OCAML_BREWCHECK`
+    environment variable; this will instruct the build to see if a _brewed_
+    version os sqlite is installed and route `pkg-config` appropriately.
 
 Credits
 -------

--- a/myocamlbuild.ml
+++ b/myocamlbuild.ml
@@ -712,7 +712,11 @@ let pkg_export =
   let env = BaseEnvLight.load () in
   let bcs = BaseEnvLight.var_get "brewcheck" env in
   let bcs = try bool_of_string bcs with _ -> false in
-  if not bcs then ""
+  let proc_env =
+    try ignore (Sys.getenv "SQLITE3_OCAML_BREWCHECK"); true
+    with _ -> false
+  in
+  if not (bcs || proc_env) then ""
   else
     let cmd = "brew ls sqlite | grep pkgconfig" in
     match read_lines_from_cmd ~max_lines:1 cmd with


### PR DESCRIPTION
To address the issues raised at the end of this [issue](https://github.com/mmottl/sqlite3-ocaml/pull/8#issuecomment-157496476). The brew checking logic can now be triggered via an environment variable `SQLITE3_OCAML_BREWCHECK` so that the install does not depend on `opam` or other package manager.