### PR TITLE
Added NetBSD and DragonFly to C detection #if

### DIFF
--- a/lib/sqlite3_stubs.c
+++ b/lib/sqlite3_stubs.c
@@ -41,7 +41,7 @@
 
 #if __GNUC__ >= 3
 # define inline inline __attribute__ ((always_inline))
-# if !defined(__FreeBSD__) && !__APPLE__
+# if !defined(__FreeBSD__) && !defined(__NetBSD__) && !defined(__DragonFly) && !__APPLE__
 # define __unused __attribute__ ((unused))
 # endif
 #else


### PR DESCRIPTION
This is a small patch to sqlite3_stubs.c - basically extending the #if to take into account the fact that NetBSD and DragonflyBSD behave similar to FreeBSD.