### PR TITLE
Add function row_blobs: stmt -> row

### DIFF
--- a/src/sqlite3.ml
+++ b/src/sqlite3.ml
@@ -200,6 +200,7 @@ external finalize : stmt -> Rc.t = "caml_sqlite3_stmt_finalize"
 
 external data_count : stmt -> int = "caml_sqlite3_data_count"
 external column_count : stmt -> int = "caml_sqlite3_column_count"
+external column_blob : stmt -> int -> string option = "caml_sqlite3_column_blob"
 external column : stmt -> int -> Data.t = "caml_sqlite3_column"
 external column_name : stmt -> int -> string = "caml_sqlite3_column_name"
 
@@ -224,6 +225,7 @@ external busy_timeout : db -> int -> unit = "caml_sqlite3_busy_timeout"
 external enable_load_extension :
   db -> bool -> bool = "caml_sqlite3_enable_load_extension"
 
+let row_blobs stmt = Array.init (data_count stmt) (column_blob stmt)
 let row_data stmt = Array.init (data_count stmt) (column stmt)
 let row_names stmt = Array.init (data_count stmt) (column_name stmt)
 let row_decltypes stmt = Array.init (data_count stmt) (column_decltype stmt)

--- a/src/sqlite3.mli
+++ b/src/sqlite3.mli
@@ -165,7 +165,7 @@ val db_open :
   db
 (** [db_open ?mode ?mutex ?cache ?vfs filename] opens the database file
     [filename], and returns a database handle.
-    
+
     Special filenames: ":memory:" and "" open an in-memory or temporary
     database respectively.
     Behaviour explained here: https://www.sqlite.org/inmemorydb.html
@@ -376,6 +376,14 @@ external column_count : stmt -> int = "caml_sqlite3_column_count"
     @raise SqliteError if the statement is invalid.
 *)
 
+external column_blob : stmt -> int -> string option = "caml_sqlite3_column_blob"
+(** [column stmt n] @return the bytes in column [n] of the
+    result of the last step of statement [stmt].
+
+    @raise RangeError if [n] is out of range.
+    @raise SqliteError if the statement is invalid.
+*)
+
 external column : stmt -> int -> Data.t = "caml_sqlite3_column"
 (** [column stmt n] @return the data in column [n] of the
     result of the last step of statement [stmt].
@@ -453,6 +461,13 @@ external clear_bindings : stmt -> Rc.t = "caml_sqlite3_clear_bindings"
 
 
 (** {2 Stepwise query convenience functions} *)
+
+val row_blobs : stmt -> row
+(** [row_blobs stmt] @return all data in the row returned by the
+    last query step performed with statement [stmt].
+
+    @raise SqliteError if the statement is invalid.
+*)
 
 val row_data : stmt -> Data.t array
 (** [row_data stmt] @return all data values in the row returned by the

--- a/src/sqlite3_stubs.c
+++ b/src/sqlite3_stubs.c
@@ -948,6 +948,27 @@ CAMLprim value caml_sqlite3_column_count(value v_stmt)
   return Val_int(sqlite3_column_count(stmt));
 }
 
+CAMLprim value caml_sqlite3_column_blob(value v_stmt, value v_index)
+{
+  CAMLparam1(v_stmt);
+  CAMLlocal1(v_tmp);
+  value v_res;
+  sqlite3_stmt *stmt = safe_get_stmtw("column_blob", v_stmt)->stmt;
+  int i = Int_val(v_index);
+  range_check(i, sqlite3_column_count(stmt));
+  if (sqlite3_column_type(stmt, i) == SQLITE_NULL) {
+    v_res = Val_int(0);
+  } else {
+    const void *blob = sqlite3_column_blob(stmt, i);
+    int len = sqlite3_column_bytes(stmt, i);
+    v_tmp = caml_alloc_string(len);
+    memcpy(String_val(v_tmp), blob, len);
+    v_res = caml_alloc_small(1, 0);
+    Field(v_res, 0) = v_tmp;
+  }
+  CAMLreturn(v_res);
+}
+
 CAMLprim value caml_sqlite3_column(value v_stmt, value v_index)
 {
   CAMLparam1(v_stmt);


### PR DESCRIPTION
A new function (+ glue code) is added:

    val row_blobs: stmt -> row

which lets you avoid going through `Data` to implement the same callback API as `exec` when using `prepare` (going through `Data` is can be inconvenient due to `Sqlite`'s dynamic typing).
