### PR TITLE
Add support for more SQLITE_OPEN_ flags

### DIFF
--- a/src/sqlite3.ml
+++ b/src/sqlite3.ml
@@ -156,14 +156,14 @@ module Cache = struct
 end
 
 external db_open :
-  mode : Mode.t -> mutex : Mut.t -> cache : Cache.t ->
-  ?vfs : string -> string -> db = "caml_sqlite3_open"
+  mode : Mode.t -> uri : bool -> memory : bool -> mutex : Mut.t -> cache : Cache.t ->
+  ?vfs : string -> string -> db = "caml_sqlite3_open_bytecode" "caml_sqlite3_open_native"
 
-let db_open ?mode ?mutex ?cache ?vfs name =
+let db_open ?mode ?(uri=false) ?(memory=false) ?mutex ?cache ?vfs name =
   let mode = Mode.lift mode in
   let mutex = Mut.lift mutex in
   let cache = Cache.lift cache in
-  db_open ~mode ~mutex ~cache ?vfs name
+  db_open ~mode ~uri ~memory ~mutex ~cache ?vfs name
 
 external db_close : db -> bool = "caml_sqlite3_close"
 

--- a/src/sqlite3.mli
+++ b/src/sqlite3.mli
@@ -159,6 +159,8 @@ end
 
 val db_open :
   ?mode : [ `READONLY | `NO_CREATE ] ->
+  ?uri : bool ->
+  ?memory : bool ->
   ?mutex : [ `NO | `FULL ] ->
   ?cache : [ `SHARED | `PRIVATE ] ->
   ?vfs : string ->
@@ -171,18 +173,24 @@ val db_open :
     database respectively.
     Behaviour explained here: https://www.sqlite.org/inmemorydb.html
 
-    The optional arguments [mode] and [mutex] are only meaningful with SQLite
-    versions >= 3.5, [cache] only for versions >= 3.6.18.  For older versions an
-    exception will be raised if any of them is set to a non-default value.  The
-    database is opened read-only if [`READONLY] is passed as mode.  The database
-    file will not be created if it is missing and [`NO_CREATE] is set.  [mutex]
-    determines how the database is accessed.  The mutex parameters [`NO] and
-    [`FULL] correspond to [SQLITE_OPEN_NOMUTEX] and [SQLITE_OPEN_FULLMUTEX] in
-    the SQLite3 API respectively.  The cache parameters [`SHARED] and [`PRIVATE]
-    correspond to [SQLITE_OPEN_SHAREDCACHE] and [SQLITE_OPEN_PRIVATECACHE] in
-    the SQLite3 API respectively.
+    The optional arguments [mode], [uri], [memory] and [mutex] are only
+    meaningful with SQLite versions >= 3.5, [cache] only for versions >= 3.6.18.
+    For older versions an exception will be raised if any of them is set to a
+    non-default value.  The database is opened read-only if [`READONLY] is
+    passed as mode.  The database file will not be created if it is missing and
+    [`NO_CREATE] is set.  The [uri] parameter enables URI filename
+    interepretation and corresponds to [SQLITE_OPEN_URI] in the SQLite3 API.
+    The [memory] parameter opens an in-memory database and corresponds to
+    [SQLITE_OPEN_MEMORY] in the SQLite3 API.   [mutex] determines how the
+    database is accessed.  The mutex parameters [`NO] and [`FULL] correspond to
+    [SQLITE_OPEN_NOMUTEX] and [SQLITE_OPEN_FULLMUTEX] in the SQLite3 API
+    respectively.  The cache parameters [`SHARED] and [`PRIVATE] correspond to
+    [SQLITE_OPEN_SHAREDCACHE] and [SQLITE_OPEN_PRIVATECACHE] in the SQLite3 API
+    respectively.
 
     @param mode default = read-write, create
+    @param uri default = false
+    @param memory default = false
     @param mutex default = nothing
     @param cache default = nothing
     @param vfs default = nothing

--- a/src/sqlite3_stubs.c
+++ b/src/sqlite3_stubs.c
@@ -63,6 +63,10 @@
 # define SQLITE_HAS_OPEN_V2
 #endif
 
+#if SQLITE_VERSION_NUMBER >= 3006000
+# define SQLITE_HAS_OPEN_MUTEX_PARAMS
+#endif
+
 #if SQLITE_VERSION_NUMBER >= 3006018
 # define SQLITE_HAS_OPEN_CACHE_PARAMS
 #endif
@@ -390,8 +394,14 @@ static inline int get_open_flags(value v_mode, value v_uri, value v_memory, valu
   }
   switch (Int_val(v_mutex)) {
     case 0 : break;
+#ifdef SQLITE_HAS_OPEN_MUTEX_PARAMS
     case 1 : flags |= SQLITE_OPEN_NOMUTEX; break;
     default : flags |= SQLITE_OPEN_FULLMUTEX; break;
+#else
+    default :
+      caml_failwith(
+        "SQLite3 version < 3.6.0 does not support mutex parameters for open");
+#endif
   }
   switch (Int_val(v_cache)) {
     case 0 : break;


### PR DESCRIPTION
This PR adds support for `SQLITE_OPEN_URI` and `SQLITE_OPEN_MEMORY` flags which are very helpful if one needs to have one or several in-memory database(s) shared between connections.