### PR TITLE
Simplified exception usage pattern

### DIFF
--- a/src/sqlite3.ml
+++ b/src/sqlite3.ml
@@ -72,7 +72,6 @@ module Rc = struct
     | DONE
     | UNKNOWN of unknown
 
-
   let to_string = function
     | OK -> "OK"
     | ERROR -> "ERROR"

--- a/src/sqlite3.ml
+++ b/src/sqlite3.ml
@@ -30,6 +30,7 @@ open Printf
 exception InternalError of string
 exception Error of string
 exception RangeError of int * int
+exception SqliteError of string
 
 type db
 type stmt
@@ -71,6 +72,7 @@ module Rc = struct
     | DONE
     | UNKNOWN of unknown
 
+
   let to_string = function
     | OK -> "OK"
     | ERROR -> "ERROR"
@@ -102,6 +104,12 @@ module Rc = struct
     | ROW -> "ROW"
     | DONE -> "DONE"
     | UNKNOWN n -> sprintf "UNKNOWN %d" (int_of_unknown n)
+
+  let check (rc: t): unit = 
+    match rc with
+    | OK | DONE -> ()
+    | err -> 
+      raise (SqliteError (to_string err))
 end
 
 module Data = struct

--- a/src/sqlite3.mli
+++ b/src/sqlite3.mli
@@ -46,6 +46,12 @@ exception RangeError of int * int
     entry of the returned tuple is the specified index, the second is
     the limit which was violated. *)
 
+exception SqliteError of string
+(** If you wish to have sqlite throw an exception when an unexpected
+    result code is returned from an sqlite operation, call [check] on
+    your [Rc.t] result and it will throw an [SqliteError rc] if the
+    code does not indicate success. *)
+
 
 (** {2 Types} *)
 
@@ -129,8 +135,11 @@ module Rc : sig
 
   val to_string : t -> string
   (** [to_string rc] converts return code [rc] to a string. *)
-end
 
+  val check : t -> unit
+  (** [check rc] raise an exception if [rc] returned failure *)
+
+end
 
 (** {2 Column data types} *)
 

--- a/test/test_error.ml
+++ b/test/test_error.ml
@@ -6,8 +6,21 @@ exception This_function_always_fails
 let%test "test_error" =
   let db = db_open "t" in
   create_fun0 db "MYERROR" (fun () -> raise This_function_always_fails);
-  try
-    let res = exec db "SELECT MYERROR();" in
-    prerr_endline ("Should have thrown an error: " ^ Rc.to_string res);
-    false
-  with This_function_always_fails -> print_endline "Ok"; true
+  let first_test = 
+    try
+      let res = exec db "SELECT MYERROR();" in
+      prerr_endline ("Should have thrown an error: " ^ Rc.to_string res);
+      false
+    with This_function_always_fails -> print_endline "Ok"; true
+  in
+
+  (* This pattern shows typical usage *)
+  exec db "PRAGMA synchronous = OFF;" |> Rc.check;
+  exec db "PRAGMA journal_mode = MEMORY;" |> Rc.check;
+  let second_test = 
+    try
+      exec db "THIS SHOULD THROW AN EXCEPTION;; BECAUSE IT IS NOT VALID;;" |> Rc.check;
+      false
+    with SqliteError _ -> print_endline "Ok"; true
+  in
+  (first_test && second_test)


### PR DESCRIPTION
Using the ocaml sqlite library, I find I have to check result codes often.  In many cases, I have to chain lots of operations right after each other (e.g. binding ten values to a statement) and I don't really want to write lots of code to check each result.

This PR enables usage of an exception-based pattern, such as this:

```
Sqlite3.bind stmt 1 (Sqlite3.Data.INT (Int64.of_int nsid)) |> Rc.check;
Sqlite3.bind stmt 2 (Sqlite3.Data.INT file_hash) |> Rc.check;
Sqlite3.bind stmt 3 (Sqlite3.Data.TEXT symbol.sif_name) |> Rc.check;
``` 

It then throws an exception if any of the statements returns a problem.