### PR TITLE
Enable quick prepare-or-reset behavior

### DIFF
--- a/src/sqlite3.ml
+++ b/src/sqlite3.ml
@@ -202,6 +202,21 @@ external recompile : stmt -> unit = "caml_sqlite3_recompile"
 external step : stmt -> Rc.t = "caml_sqlite3_step"
 external reset : stmt -> Rc.t = "caml_sqlite3_stmt_reset"
 
+let prepare_or_reset
+    (db: db)
+    (stmt_ref: stmt option ref)
+    (sql: string): stmt =
+  let stmt = match !stmt_ref with
+    | Some s ->
+      reset s |> Rc.check;
+      s
+    | None ->
+      let s = prepare db sql in
+      stmt_ref := Some s;
+      s
+  in
+  stmt
+
 external sleep : (int [@untagged]) -> (int [@untagged])
   = "caml_sqlite3_sleep_bc" "caml_sqlite3_sleep"
 

--- a/src/sqlite3.mli
+++ b/src/sqlite3.mli
@@ -310,6 +310,13 @@ val prepare : db -> string -> stmt
     @raise SqliteError if the statement could not be prepared.
 *)
 
+val prepare_or_reset : db -> stmt option ref -> string -> stmt
+(** [prepare_or_reset db stmt_opt sql] will either compile a new
+    statement or reset an existing statement.  This is useful for
+    executing multiple identical commands in a loop since it will 
+    prepare the statement on first usage but reuse it afterwards.
+ *)
+
 val prepare_tail : stmt -> stmt option
 (** [prepare_tail stmt] compile the remaining part of the SQL-statement
     [stmt] to bytecode.  @return [None] if there was no remaining part,

--- a/test/test_stmt.ml
+++ b/test/test_stmt.ml
@@ -47,6 +47,13 @@ let%test "test_stmt" =
     ignore (prepare_tail (prepare db sql))
   done;
 
+  let premade_statement = ref None in
+  for _i = 0 to 100 do
+    (* Printf.printf "Create statement %d\n%!" i; *)
+    let sql = Printf.sprintf "SELECT * FROM tbl0; SELECT * FROM tbl1;" in
+    ignore (prepare_or_reset db premade_statement sql)
+  done;
+
   for _i = 1 to 10 do
     (* Printf.printf "Create statement %d\n%!" i; *)
     let sql = Printf.sprintf "SELECT * FROM tbl0; SELECT * FROM tbl1;" in


### PR DESCRIPTION
When executing simple commands in a tight loop, resetting a statement provides performance benefits compared to preparing a new statement.  This function allows the statement to be prepared on first use and reset for each following use.