### PR TITLE
[RFC] Type conversion for sqlite data types

### DIFF
--- a/src/sqlite3.mli
+++ b/src/sqlite3.mli
@@ -46,6 +46,9 @@ exception RangeError of int * int
     entry of the returned tuple is the specified index, the second is
     the limit which was violated. *)
 
+exception DataTypeError of string
+(** [DataTypeError (msg)] is raised when you attempt to convert a
+    Data.t structure to an object via an invalid conversion. *)
 
 (** {2 Types} *)
 
@@ -144,9 +147,71 @@ module Data : sig
     | TEXT of string
     | BLOB of string
 
-  val to_string : t -> string
-  (** [to_string data] converts [data] to a string.  Both [NONE] and
-      [NULL] are converted to the empty string. *)
+  val from_string : string option -> t
+  (** [from_string value] converts [value] to a `Data.t`, 
+      converting `None` to sqlite `NULL`. *)
+
+  val from_int : int option -> t
+  (** [from_int value] converts [value] to a `Data.t`, 
+      converting `None` to sqlite `NULL`. *)
+
+  val from_int64 : int64 option -> t
+  (** [from_int64 value] converts [value] to a `Data.t`, 
+      converting `None` to sqlite `NULL`. *)
+
+  val from_float : float option -> t
+  (** [from_float value] converts [value] to a `Data.t`, 
+      converting `None` to sqlite `NULL`. *)
+
+  val from_bool : bool option -> t
+  (** [from_bool value] converts [value] to a `Data.t`, 
+      converting `None` to sqlite `NULL`. *)
+
+  val to_string_exn : t -> string
+  (** [to_string_exn data] converts [data] to a string, and raises
+      an exception if it is not a valid conversion. This method
+      also converts data of type BLOB to a string. *)
+
+  val to_int_exn : t -> int
+  (** [to_int_exn data] converts [data] to an int, and raises
+      an exception if it is not a valid conversion. *)
+
+  val to_int64_exn : t -> int64
+  (** [to_int64_exn data] converts [data] to an int64, and raises
+      an exception if it is not a valid conversion. *)
+
+  val to_float_exn : t -> float
+  (** [to_float_exn data] converts [data] to a float, and raises
+      an exception if it is not a valid conversion. *)
+
+  val to_bool_exn : t -> bool
+  (** [to_bool_exn data] converts [data] to a bool, and raises
+      an exception if it is not a valid conversion. *)
+
+  val to_string : t -> string option
+  (** [to_string data] converts [data] to `Some string` or 
+      `None` if it is not a valid conversion. This method
+      also converts data of type BLOB to a string. *)
+
+  val to_int : t -> int option
+  (** [to_int data] converts [data] to `Some int` or 
+      `None` if it is not a valid conversion. *)
+
+  val to_int64 : t -> int64 option
+  (** [to_int64 data] converts [data] to `Some int64` or 
+      `None` if it is not a valid conversion. *)
+
+  val to_float : t -> float option
+  (** [to_float data] converts [data] to `Some float` or 
+      `None` if it is not a valid conversion. *)
+      
+  val to_bool : t -> bool option
+  (** [to_bool data] converts [data] to `Some bool` or 
+      `None` if it is not a valid conversion. *)
+  
+  val to_string_coerce : t -> string
+  (** [to_string_unsafe data] coerces [data] to a string, using coercion
+      on ints, NULLs, floats, and other data types. *)
 
   val to_string_debug : t -> string
   (** [to_string_debug data] converts [data] to a string including the

--- a/test/test_stmt.ml
+++ b/test/test_stmt.ml
@@ -11,7 +11,7 @@ let stepbystep s =
       Printf.printf "%s column[%d] %s = %s\n%!"
         (column_decltype s i) i
         (column_name s i)
-        (Data.to_string (column s i))
+        (Data.to_string_coerce (column s i))
     done
   done
 
@@ -21,7 +21,7 @@ let stepbystep_wrong s =
       Printf.printf "%s column[%d] %s = %s\n%!"
         (column_decltype s i) i
         (column_name s i)
-        (Data.to_string (column s i))
+        (Data.to_string_coerce (column s i))
     done
   done
 

--- a/test/test_values.ml
+++ b/test/test_values.ml
@@ -1,0 +1,79 @@
+open Sqlite3
+
+let%test "test_values" =
+
+  (* Sql statements for this test *)
+  let schema = "CREATE TABLE test_values ( " ^
+  "    row_id INTEGER NOT NULL, " ^
+  "    string_col TEXT NULL, " ^
+  "    int_col INT NULL, " ^
+  "    int64_col INT NULL, " ^
+  "    float_col FLOAT NULL, " ^
+  "    bool_col INT NULL" ^
+  ");" 
+  in
+  let insert_sql = "INSERT INTO test_values " ^
+    "(row_id, string_col, int_col, int64_col, float_col, bool_col) " ^
+    "VALUES (?, ?, ?, ?, ?, ?)"
+  in
+  let select_sql = "SELECT " ^
+    "string_col, int_col, int64_col, float_col, bool_col " ^
+    "FROM test_values WHERE row_id = ?"
+  in
+
+  (* Construct database and statements *)
+  let db = db_open "test_values" in
+  let rc = exec db schema in
+  Printf.printf "Created schema: %s" (Rc.to_string rc);
+  let insert_stmt = prepare db insert_sql in
+  let select_stmt = prepare db select_sql in
+
+  (* Insert values in row 1 *)
+  let test_float_val = 56.789 in
+  ignore (reset insert_stmt);
+  ignore (bind insert_stmt 1 (Sqlite3.Data.INT 1L));
+  ignore (bind insert_stmt 2 (Data.from_string (Some "Hi Mom")));
+  ignore (bind insert_stmt 3 (Data.from_int (Some 1)));
+  ignore (bind insert_stmt 4 (Data.from_int64 (Some Int64.max_int)));
+  ignore (bind insert_stmt 5 (Data.from_float (Some test_float_val)));
+  ignore (bind insert_stmt 6 (Data.from_bool (Some true)));
+  ignore (step insert_stmt);
+
+  (* Insert nulls in row 2 *)
+  ignore (reset insert_stmt);
+  ignore (bind insert_stmt 1 (Sqlite3.Data.INT 2L));
+  ignore (bind insert_stmt 2 (Data.from_string (None)));
+  ignore (bind insert_stmt 3 (Data.from_int (None)));
+  ignore (bind insert_stmt 4 (Data.from_int64 (None)));
+  ignore (bind insert_stmt 5 (Data.from_float (None)));
+  ignore (bind insert_stmt 6 (Data.from_bool (None)));
+  ignore (step insert_stmt);
+
+  (* Fetch data back with values *)
+  ignore (reset select_stmt);
+  ignore (bind select_stmt 1 (Sqlite3.Data.INT 1L));
+  if Sqlite3.step select_stmt = Sqlite3.Rc.ROW then begin
+    assert ((Data.to_string_exn (column select_stmt 0)) = "Hi Mom");
+    assert ((Data.to_int_exn (column select_stmt 1)) = 1);
+    assert ((Data.to_int64_exn (column select_stmt 2)) = Int64.max_int);
+    assert ((Data.to_float_exn (column select_stmt 3)) = test_float_val);
+    assert ((Data.to_bool_exn (column select_stmt 4)) = true);
+  end;
+
+  (* Fetch data back with nulls *)
+  ignore (reset select_stmt);
+  ignore (bind select_stmt 1 (Sqlite3.Data.INT 2L));
+  if Sqlite3.step select_stmt = Sqlite3.Rc.ROW then begin
+    assert ((Data.to_string (column select_stmt 0)) = None);
+    assert ((Data.to_int (column select_stmt 1)) = None);
+    assert ((Data.to_int64 (column select_stmt 2)) = None);
+    assert ((Data.to_float (column select_stmt 3)) = None);
+    assert ((Data.to_bool (column select_stmt 4)) = None);
+  end;
+
+  (* Clean up *)
+  ignore (finalize insert_stmt);
+  ignore (finalize select_stmt);
+  assert (db_close db);
+  true
+


### PR DESCRIPTION
Request for comments: 

It would be useful if this library included common type conversions.  In one common pattern, I'd convert sql `NULL` to `None`; in the other pattern I'd raise an exception for any value that could not be converted.

The existing `to_string` function is a convenient way to guarantee a string, but it behaves differently. 
 Since it coerces any data type to a string, I renamed it `to_string_coerce` to differentiate it from `to_string` and `to_string_exn`.  Is there a better name for that style of conversion?

The end result is a pattern that looks like this:

```
assert ((Data.to_string_exn (column select_stmt 0)) = "Hi Mom");
``` 
or
```
assert ((Data.to_string (column select_stmt 0)) = Some "Hi Mom");
```

I'm curious if you think we should improve the pattern further, such as by replacing the call to `column`?  For example, we could simplify it further to look like this:

```
assert ((get_string select_stmt 0) = Some "Hi Mom");
```