### PR TITLE
Use sqlite3 close v2() over sqlite3_close()

### DIFF
--- a/src/sqlite3_stubs.c
+++ b/src/sqlite3_stubs.c
@@ -65,6 +65,12 @@
 # define SQLITE_HAS_OPEN_V2
 #endif
 
+#if SQLITE_VERSION_NUMBER >= 3007014
+# define my_sqlite3_close sqlite3_close_v2
+#else
+# define my_sqlite3_close sqlite3_close
+#endif
+
 #if SQLITE_VERSION_NUMBER >= 3006000
 # define SQLITE_HAS_OPEN_MUTEX_PARAMS
 #endif
@@ -395,7 +401,7 @@ static inline void ref_count_finalize_dbw(db_wrap *dbw)
       caml_stat_free(link);
     }
     dbw->user_functions = NULL;
-    sqlite3_close(dbw->db);
+    my_sqlite3_close(dbw->db);
     caml_stat_free(dbw);
   }
 }
@@ -506,7 +512,7 @@ CAMLprim value caml_sqlite3_open(
     const char *msg;
     if (db) {
       msg = sqlite3_errmsg(db);
-      sqlite3_close(db);
+      my_sqlite3_close(db);
     }
     else msg = "<unknown_error>";
     raise_sqlite3_Error("error opening database: %s", msg);
@@ -538,7 +544,7 @@ CAMLprim value caml_sqlite3_close(value v_db)
   int ret, not_busy;
   db_wrap *dbw = Sqlite3_val(v_db);
   check_db(dbw, "close");
-  ret = sqlite3_close(dbw->db);
+  ret = my_sqlite3_close(dbw->db);
   not_busy = ret != SQLITE_BUSY;
   if (not_busy) dbw->db = NULL;
   return Val_bool(not_busy);

--- a/src/sqlite3_stubs.c
+++ b/src/sqlite3_stubs.c
@@ -509,12 +509,16 @@ CAMLprim value caml_sqlite3_open(
   caml_leave_blocking_section();
 
   if (res) {
-    const char *msg;
+    char msg[1024];
     if (db) {
-      msg = sqlite3_errmsg(db);
+      /* Can't use sqlite3_errmsg()'s return value after closing the
+         database. */
+      snprintf(msg, sizeof msg, "%s", sqlite3_errmsg(db));
       my_sqlite3_close(db);
     }
-    else msg = "<unknown_error>";
+    else {
+      strcpy(msg, "<unknown_error>");
+    }
     raise_sqlite3_Error("error opening database: %s", msg);
   } else if (db == NULL)
     raise_sqlite3_InternalError(


### PR DESCRIPTION
The v2 function is better suited for garbage collected languages like ocaml - from [the documentation](https://www.sqlite.org/c3ref/close.html)

> If sqlite3_close_v2() is called with unfinalized prepared statements and/or unfinished sqlite3_backups, then the database connection becomes an unusable "zombie" which will automatically be deallocated when the last prepared statement is finalized or the last sqlite3_backup is finished. The sqlite3_close_v2() interface is intended for use with host languages that are garbage collected, and where the order in which destructors are called is arbitrary.

In particular, manually calling `Sqlite3.db_close` when there are unfinalized prepared statements will  succeed instead of failing like it does now.

Also fixed a use-after-free bug when opening a database fails - the code tried to use a string after closing the database freed it.
 