### PR TITLE
Add let-operator to safely close DB

### DIFF
--- a/src/sqlite3.ml
+++ b/src/sqlite3.ml
@@ -281,6 +281,12 @@ let db_open ?mode ?(uri = false) ?(memory = false) ?mutex ?cache ?vfs name =
 
 external db_close : db -> bool = "caml_sqlite3_close"
 
+let ( let& ) db f =
+  let close_or_exn () =
+    if not (db_close db) then failwith "Could not close database"
+  in
+  Fun.protect ~finally:close_or_exn (fun () -> f db)
+
 external errcode : db -> Rc.t = "caml_sqlite3_errcode"
 external errmsg : db -> string = "caml_sqlite3_errmsg"
 

--- a/src/sqlite3.mli
+++ b/src/sqlite3.mli
@@ -343,6 +343,13 @@ val db_close : db -> bool
     @raise SqliteError if an invalid database handle is passed.
 *)
 
+val ( let& ) : db -> (db -> 'a) -> 'a
+(** [let& db = db_open "..." in ...scope that uses db...] ensures that the
+    database [db] is safely closed at the end of the scope, even if there is an
+    exception somewhere in the scope.
+
+    @raise Failure if the database could not be closed successfully. *)
+
 val enable_load_extension : db -> bool -> bool
 (** [enable_load_extension db onoff] enable/disable the SQLite3 load
     extension.  @return [false] if the operation fails, [true]

--- a/src/sqlite3.mli
+++ b/src/sqlite3.mli
@@ -348,7 +348,7 @@ val ( let& ) : db -> (db -> 'a) -> 'a
     database [db] is safely closed at the end of the scope, even if there is an
     exception somewhere in the scope.
 
-    @raise Failure if the database could not be closed successfully. *)
+    @raise Fun.Finally_raised if the database could not be closed successfully. *)
 
 val enable_load_extension : db -> bool -> bool
 (** [enable_load_extension db onoff] enable/disable the SQLite3 load


### PR DESCRIPTION
This can be used as a convenience, instead of having to manually call
`db_close` or remember to set up the close in some other way.