### PR TITLE
Add extended_errcode_int function.

### DIFF
--- a/src/sqlite3.ml
+++ b/src/sqlite3.ml
@@ -290,6 +290,7 @@ let ( let& ) db f =
 
 external errcode : db -> Rc.t = "caml_sqlite3_errcode"
 external errmsg : db -> string = "caml_sqlite3_errmsg"
+external extended_errcode_int : db -> int = "caml_sqlite3_extended_errcode_int"
 
 external last_insert_rowid : db -> (int64 [@unboxed])
   = "caml_sqlite3_last_insert_rowid_bc" "caml_sqlite3_last_insert_rowid"

--- a/src/sqlite3.mli
+++ b/src/sqlite3.mli
@@ -370,6 +370,12 @@ val errmsg : db -> string
     @raise SqliteError if an invalid database handle is passed.
 *)
 
+val extended_errcode_int : db -> int
+(** [extended_errcode_int db] @return the extended error code of the last
+    operation on the database [db] as an integer.
+
+    @raise SqliteError if an invalid database handle is passed. *)
+
 val last_insert_rowid : db -> int64
 (** [last_insert_rowid db] @return the index of the row inserted by
     the last operation on database [db].

--- a/src/sqlite3_stubs.c
+++ b/src/sqlite3_stubs.c
@@ -580,6 +580,13 @@ CAMLprim value caml_sqlite3_errcode(value v_db)
   return Val_rc(sqlite3_errcode(dbw->db));
 }
 
+CAMLprim value caml_sqlite3_extended_errcode_int(value v_db)
+{
+  db_wrap *dbw = Sqlite3_val(v_db);
+  check_db(dbw, "extended_errcode");
+  return Val_int(sqlite3_extended_errcode(dbw->db));
+}
+
 CAMLprim value caml_sqlite3_errmsg(value v_db)
 {
   db_wrap *dbw = Sqlite3_val(v_db);


### PR DESCRIPTION
This is a simplified alternative to #51, only defining the integer-returning function. This avoids making design decision now about the form of the extended error codes. This will suffice for solving paurkedal/ocaml-caqti#72, since I will need to define an independent set of errors to smooth out the difference between the different database client libraries anyway.