### PR TITLE
Support MSVC compiler

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+### Pending
+
+  * Don't use `-lpthread` and non-MSVC flags with MSVC compiler
+
 ### 5.1.0 (2021-09-22)
 
   * Added let&-operator for implicit closing of an opened database.

--- a/src/dune
+++ b/src/dune
@@ -3,8 +3,8 @@
   (foreign_stubs
     (language c)
     (names sqlite3_stubs)
-    (flags (:standard) (:include c_flags.sexp) -O2 -fPIC -DPIC))
-  (c_library_flags (:include c_library_flags.sexp) -lpthread)
+    (flags (:standard) (:include c_flags.sexp)))
+  (c_library_flags (:include c_library_flags.sexp))
 )
 
 (rule


### PR DESCRIPTION
- No assuming -lpthread and -O2 -fPIC are valid for all compilers
- This commit/PR fixes the release profile only, and does not touch the -Wextra used in the dev profile that is invalid in MSVC

Fix for issue https://github.com/diskuv/dkml-installer-ocaml/issues/57