### PR TITLE
Add user collation support

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -9,7 +9,6 @@
 - Add the following wrappers:
 
   - Better SQL Function support (aggregating ones)
-  - Collation support
   - Authorization support
   - Trace/profile support
   - progress handler support

--- a/lib/sqlite3.ml
+++ b/lib/sqlite3.ml
@@ -525,6 +525,14 @@ module Aggregate = struct
       value final
 end
 
+(* Collation registration *)
+
+external create_collation : db -> string -> (string -> string -> int) -> unit
+  = "caml_sqlite3_create_collation"
+
+external delete_collation : db -> string -> unit
+  = "caml_sqlite3_delete_collation"
+
 module Backup = struct
   module Raw = struct
     type t

--- a/lib/sqlite3.mli
+++ b/lib/sqlite3.mli
@@ -943,6 +943,20 @@ module Aggregate : sig
       @raise SqliteError if an invalid database handle is passed. *)
 end
 
+val create_collation : db -> string -> (string -> string -> int) -> unit
+(** [create_collation db name func] creates a collation with [name] in database
+    handle [db]. [func] is called when the collation is needed, it must return
+    an integer that is negative, zero, or positive if the first string is less
+    than, equal to, or greater than the second, respectively
+
+    @raise SqliteError if an invalid database handle is passed. *)
+
+val delete_collation : db -> string -> unit
+(** [delete_collation db name] deletes collation with name [name] from database
+    handle [db].
+
+    @raise SqliteError if an invalid database handle is passed. *)
+
 module Backup : sig
   type t
   (** Type of a backup between two databases *)

--- a/test/test_collation.ml
+++ b/test/test_collation.ml
@@ -1,0 +1,58 @@
+open Sqlite3
+
+let assert_ok rc = assert (rc = Rc.OK)
+let assert_error rc = assert (rc = Rc.ERROR)
+
+let assert_rows_equal expected_rows db sql =
+  let actual_rows = ref [] in
+  let _ =
+    assert_ok
+      (exec db sql ~cb:(fun row _ ->
+           match row.(0) with
+           | Some a -> actual_rows := a :: !actual_rows
+           | _ -> ()))
+  in
+  let actual_rows = List.sort compare (List.rev !actual_rows) in
+  assert (actual_rows = expected_rows)
+
+let%test "test_collation" =
+  let db = db_open "t_collation" in
+  create_collation db "FIRST_CHAR" (fun left right ->
+      compare (String.get left 0) (String.get right 0));
+
+  let found_first_char = ref false in
+  let _ =
+    assert_ok
+      (exec db "PRAGMA collation_list" ~cb:(fun row _ ->
+           match row.(1) with
+           | Some a -> found_first_char := !found_first_char || a = "FIRST_CHAR"
+           | _ -> ()))
+  in
+  assert !found_first_char;
+
+  assert_ok (exec db "DROP TABLE IF EXISTS tbl");
+  assert_ok (exec db "CREATE TABLE tbl (a varchar(10) COLLATE FIRST_CHAR)");
+  assert_ok (exec db "INSERT INTO tbl VALUES ('pippo')");
+  assert_ok (exec db "INSERT INTO tbl VALUES ('pippo2')");
+  assert_ok (exec db "INSERT INTO tbl VALUES ('atypical')");
+  assert_rows_equal [ "pippo"; "pippo2" ] db
+    "SELECT * FROM tbl WHERE a = 'pippo'";
+  assert_rows_equal [ "pippo"; "pippo2" ] db
+    "SELECT * FROM tbl WHERE a = 'papa'";
+  assert_rows_equal [ "atypical" ] db
+    "SELECT * FROM tbl WHERE a = 'asymmetrical'";
+  assert_rows_equal [ "atypical" ] db "SELECT * FROM tbl WHERE a = 'atypical'";
+  assert_rows_equal [] db "SELECT * FROM tbl WHERE a = 'border'";
+
+  assert_ok (exec db "DROP TABLE IF EXISTS tbl");
+  assert_ok (exec db "CREATE TABLE tbl (a varchar(10))");
+  assert_ok (exec db "INSERT INTO tbl VALUES ('pippo')");
+  assert_ok (exec db "INSERT INTO tbl VALUES ('pippo2')");
+  assert_rows_equal [ "pippo" ] db "SELECT * FROM tbl WHERE a = 'pippo'";
+  assert_rows_equal [ "pippo"; "pippo2" ] db
+    "SELECT * FROM tbl WHERE a = 'pippo' COLLATE FIRST_CHAR";
+
+  delete_collation db "FIRST_CHAR";
+  assert_error
+    (exec db "SELECT * FROM tbl WHERE a = 'pippo' COLLATE FIRST_CHAR");
+  true


### PR DESCRIPTION
Add support to create and delete [custom collations](https://www.sqlite.org/c3ref/create_collation.html).

The functionality is similar to user functions, but there's a fixed arity (two strings) and a fixed return value (type) so the code is quite simple compared to the implementation of user functions.

Automated test is included to ensure that the functionality actually works as expected.