### PR TITLE
Atomic `db_wrap.ref_count` for multi-threaded applications

### DIFF
--- a/lib/sqlite3_stubs.c
+++ b/lib/sqlite3_stubs.c
@@ -27,6 +27,8 @@
 #include <stdio.h>
 #include <string.h>
 
+#include <stdatomic.h>
+
 #include <caml/alloc.h>
 #include <caml/callback.h>
 #include <caml/custom.h>
@@ -125,7 +127,7 @@ typedef struct user_collation {
 typedef struct db_wrap {
   sqlite3 *db;
   int rc;
-  int ref_count;
+  _Atomic(int) ref_count;
   user_function *user_functions;
   user_collation *user_collations;
 } db_wrap;


### PR DESCRIPTION
We are using sqlite3-ocaml from multi-threaded applications which require the `ref_count` to be atomic to ensure that the `db_wrap` object is freed at the right time. Without this, we see that our databases are sometimes GC'ed and closed while we still have references to it.

The solution here is very simple, but the `_Atomic` macro is C11 and I'm not sure whether the OCaml eco-system would prefer something older. (Feel free to close and implement this in a different way if you prefer!)