### PR TITLE
Support `carray` extension

### DIFF
--- a/lib/carray.c
+++ b/lib/carray.c
@@ -1,0 +1,562 @@
+/*
+** 2016-06-29
+**
+** The author disclaims copyright to this source code.  In place of
+** a legal notice, here is a blessing:
+**
+**    May you do good and not evil.
+**    May you find forgiveness for yourself and forgive others.
+**    May you share freely, never taking more than you give.
+**
+*************************************************************************
+**
+** This file demonstrates how to create a table-valued-function that
+** returns the values in a C-language array.
+** Examples:
+**
+**      SELECT * FROM carray($ptr,5)
+**
+** The query above returns 5 integers contained in a C-language array
+** at the address $ptr.  $ptr is a pointer to the array of integers.
+** The pointer value must be assigned to $ptr using the
+** sqlite3_bind_pointer() interface with a pointer type of "carray".
+** For example:
+**
+**    static int aX[] = { 53, 9, 17, 2231, 4, 99 };
+**    int i = sqlite3_bind_parameter_index(pStmt, "$ptr");
+**    sqlite3_bind_pointer(pStmt, i, aX, "carray", 0);
+**
+** There is an optional third parameter to determine the datatype of
+** the C-language array.  Allowed values of the third parameter are
+** 'int32', 'int64', 'double', 'char*', 'struct iovec'.  Example:
+**
+**      SELECT * FROM carray($ptr,10,'char*');
+**
+** The default value of the third parameter is 'int32'.
+**
+** HOW IT WORKS
+**
+** The carray "function" is really a virtual table with the
+** following schema:
+**
+**     CREATE TABLE carray(
+**       value,
+**       pointer HIDDEN,
+**       count HIDDEN,
+**       ctype TEXT HIDDEN
+**     );
+**
+** If the hidden columns "pointer" and "count" are unconstrained, then 
+** the virtual table has no rows.  Otherwise, the virtual table interprets
+** the integer value of "pointer" as a pointer to the array and "count"
+** as the number of elements in the array.  The virtual table steps through
+** the array, element by element.
+*/
+#include "sqlite3ext.h"
+SQLITE_EXTENSION_INIT1
+#include <assert.h>
+#include <string.h>
+#ifdef _WIN32
+  struct iovec {
+    void *iov_base;
+    size_t iov_len;
+  };
+#else
+# include <sys/uio.h>
+#endif
+ 
+/* Allowed values for the mFlags parameter to sqlite3_carray_bind().
+** Must exactly match the definitions in carray.h.
+*/
+#ifndef CARRAY_INT32
+# define CARRAY_INT32     0      /* Data is 32-bit signed integers */
+# define CARRAY_INT64     1      /* Data is 64-bit signed integers */
+# define CARRAY_DOUBLE    2      /* Data is doubles */
+# define CARRAY_TEXT      3      /* Data is char* */
+# define CARRAY_BLOB      4      /* Data is struct iovec* */
+#endif
+
+#ifndef SQLITE_API
+# ifdef _WIN32
+#  define SQLITE_API __declspec(dllexport)
+# else
+#  define SQLITE_API
+# endif
+#endif
+
+#ifndef SQLITE_OMIT_VIRTUALTABLE
+
+/*
+** Names of allowed datatypes
+*/
+static const char *azType[] = { "int32", "int64", "double", "char*",
+                                "struct iovec" };
+
+/*
+** Structure used to hold the sqlite3_carray_bind() information
+*/
+typedef struct carray_bind carray_bind;
+struct carray_bind {
+  void *aData;                /* The data */
+  int nData;                  /* Number of elements */
+  int mFlags;                 /* Control flags */
+  void (*xDel)(void*);        /* Destructor for aData */
+};
+
+
+/* carray_cursor is a subclass of sqlite3_vtab_cursor which will
+** serve as the underlying representation of a cursor that scans
+** over rows of the result
+*/
+typedef struct carray_cursor carray_cursor;
+struct carray_cursor {
+  sqlite3_vtab_cursor base;  /* Base class - must be first */
+  sqlite3_int64 iRowid;      /* The rowid */
+  void *pPtr;                /* Pointer to the array of values */
+  sqlite3_int64 iCnt;        /* Number of integers in the array */
+  unsigned char eType;       /* One of the CARRAY_type values */
+};
+
+/*
+** The carrayConnect() method is invoked to create a new
+** carray_vtab that describes the carray virtual table.
+**
+** Think of this routine as the constructor for carray_vtab objects.
+**
+** All this routine needs to do is:
+**
+**    (1) Allocate the carray_vtab object and initialize all fields.
+**
+**    (2) Tell SQLite (via the sqlite3_declare_vtab() interface) what the
+**        result set of queries against carray will look like.
+*/
+static int carrayConnect(
+  sqlite3 *db,
+  void *pAux,
+  int argc, const char *const*argv,
+  sqlite3_vtab **ppVtab,
+  char **pzErr
+){
+  sqlite3_vtab *pNew;
+  int rc;
+
+/* Column numbers */
+#define CARRAY_COLUMN_VALUE   0
+#define CARRAY_COLUMN_POINTER 1
+#define CARRAY_COLUMN_COUNT   2
+#define CARRAY_COLUMN_CTYPE   3
+
+  rc = sqlite3_declare_vtab(db,
+     "CREATE TABLE x(value,pointer hidden,count hidden,ctype hidden)");
+  if( rc==SQLITE_OK ){
+    pNew = *ppVtab = sqlite3_malloc( sizeof(*pNew) );
+    if( pNew==0 ) return SQLITE_NOMEM;
+    memset(pNew, 0, sizeof(*pNew));
+  }
+  return rc;
+}
+
+/*
+** This method is the destructor for carray_cursor objects.
+*/
+static int carrayDisconnect(sqlite3_vtab *pVtab){
+  sqlite3_free(pVtab);
+  return SQLITE_OK;
+}
+
+/*
+** Constructor for a new carray_cursor object.
+*/
+static int carrayOpen(sqlite3_vtab *p, sqlite3_vtab_cursor **ppCursor){
+  carray_cursor *pCur;
+  pCur = sqlite3_malloc( sizeof(*pCur) );
+  if( pCur==0 ) return SQLITE_NOMEM;
+  memset(pCur, 0, sizeof(*pCur));
+  *ppCursor = &pCur->base;
+  return SQLITE_OK;
+}
+
+/*
+** Destructor for a carray_cursor.
+*/
+static int carrayClose(sqlite3_vtab_cursor *cur){
+  sqlite3_free(cur);
+  return SQLITE_OK;
+}
+
+
+/*
+** Advance a carray_cursor to its next row of output.
+*/
+static int carrayNext(sqlite3_vtab_cursor *cur){
+  carray_cursor *pCur = (carray_cursor*)cur;
+  pCur->iRowid++;
+  return SQLITE_OK;
+}
+
+/*
+** Return values of columns for the row at which the carray_cursor
+** is currently pointing.
+*/
+static int carrayColumn(
+  sqlite3_vtab_cursor *cur,   /* The cursor */
+  sqlite3_context *ctx,       /* First argument to sqlite3_result_...() */
+  int i                       /* Which column to return */
+){
+  carray_cursor *pCur = (carray_cursor*)cur;
+  sqlite3_int64 x = 0;
+  switch( i ){
+    case CARRAY_COLUMN_POINTER:   return SQLITE_OK;
+    case CARRAY_COLUMN_COUNT:     x = pCur->iCnt;   break;
+    case CARRAY_COLUMN_CTYPE: {
+      sqlite3_result_text(ctx, azType[pCur->eType], -1, SQLITE_STATIC);
+      return SQLITE_OK;
+    }
+    default: {
+      switch( pCur->eType ){
+        case CARRAY_INT32: {
+          int *p = (int*)pCur->pPtr;
+          sqlite3_result_int(ctx, p[pCur->iRowid-1]);
+          return SQLITE_OK;
+        }
+        case CARRAY_INT64: {
+          sqlite3_int64 *p = (sqlite3_int64*)pCur->pPtr;
+          sqlite3_result_int64(ctx, p[pCur->iRowid-1]);
+          return SQLITE_OK;
+        }
+        case CARRAY_DOUBLE: {
+          double *p = (double*)pCur->pPtr;
+          sqlite3_result_double(ctx, p[pCur->iRowid-1]);
+          return SQLITE_OK;
+        }
+        case CARRAY_TEXT: {
+          const char **p = (const char**)pCur->pPtr;
+          sqlite3_result_text(ctx, p[pCur->iRowid-1], -1, SQLITE_TRANSIENT);
+          return SQLITE_OK;
+        }
+        case CARRAY_BLOB: {
+          const struct iovec *p = (struct iovec*)pCur->pPtr;
+          sqlite3_result_blob(ctx, p[pCur->iRowid-1].iov_base,
+                               (int)p[pCur->iRowid-1].iov_len, SQLITE_TRANSIENT);
+          return SQLITE_OK;
+        }
+      }
+    }
+  }
+  sqlite3_result_int64(ctx, x);
+  return SQLITE_OK;
+}
+
+/*
+** Return the rowid for the current row.  In this implementation, the
+** rowid is the same as the output value.
+*/
+static int carrayRowid(sqlite3_vtab_cursor *cur, sqlite_int64 *pRowid){
+  carray_cursor *pCur = (carray_cursor*)cur;
+  *pRowid = pCur->iRowid;
+  return SQLITE_OK;
+}
+
+/*
+** Return TRUE if the cursor has been moved off of the last
+** row of output.
+*/
+static int carrayEof(sqlite3_vtab_cursor *cur){
+  carray_cursor *pCur = (carray_cursor*)cur;
+  return pCur->iRowid>pCur->iCnt;
+}
+
+/*
+** This method is called to "rewind" the carray_cursor object back
+** to the first row of output.
+*/
+static int carrayFilter(
+  sqlite3_vtab_cursor *pVtabCursor, 
+  int idxNum, const char *idxStr,
+  int argc, sqlite3_value **argv
+){
+  carray_cursor *pCur = (carray_cursor *)pVtabCursor;
+  pCur->pPtr = 0;
+  pCur->iCnt = 0;
+  switch( idxNum ){
+    case 1: {
+      carray_bind *pBind = sqlite3_value_pointer(argv[0], "carray-bind");
+      if( pBind==0 ) break;
+      pCur->pPtr = pBind->aData;
+      pCur->iCnt = pBind->nData;
+      pCur->eType = pBind->mFlags & 0x07;
+      break;
+    }
+    case 2:
+    case 3: {
+      pCur->pPtr = sqlite3_value_pointer(argv[0], "carray");
+      pCur->iCnt = pCur->pPtr ? sqlite3_value_int64(argv[1]) : 0;
+      if( idxNum<3 ){
+        pCur->eType = CARRAY_INT32;
+      }else{
+        unsigned char i;
+        const char *zType = (const char*)sqlite3_value_text(argv[2]);
+        for(i=0; i<sizeof(azType)/sizeof(azType[0]); i++){
+          if( sqlite3_stricmp(zType, azType[i])==0 ) break;
+        }
+        if( i>=sizeof(azType)/sizeof(azType[0]) ){
+          pVtabCursor->pVtab->zErrMsg = sqlite3_mprintf(
+            "unknown datatype: %Q", zType);
+          return SQLITE_ERROR;
+        }else{
+          pCur->eType = i;
+        }
+      }
+      break;
+    }
+  }
+  pCur->iRowid = 1;
+  return SQLITE_OK;
+}
+
+/*
+** SQLite will invoke this method one or more times while planning a query
+** that uses the carray virtual table.  This routine needs to create
+** a query plan for each invocation and compute an estimated cost for that
+** plan.
+**
+** In this implementation idxNum is used to represent the
+** query plan.  idxStr is unused.
+**
+** idxNum is:
+**
+**    1    If only the pointer= constraint exists.  In this case, the
+**         parameter must be bound using sqlite3_carray_bind().
+**
+**    2    if the pointer= and count= constraints exist.
+**
+**    3    if the ctype= constraint also exists.
+**
+** idxNum is 0 otherwise and carray becomes an empty table.
+*/
+static int carrayBestIndex(
+  sqlite3_vtab *tab,
+  sqlite3_index_info *pIdxInfo
+){
+  int i;                 /* Loop over constraints */
+  int ptrIdx = -1;       /* Index of the pointer= constraint, or -1 if none */
+  int cntIdx = -1;       /* Index of the count= constraint, or -1 if none */
+  int ctypeIdx = -1;     /* Index of the ctype= constraint, or -1 if none */
+
+  const struct sqlite3_index_constraint *pConstraint;
+  pConstraint = pIdxInfo->aConstraint;
+  for(i=0; i<pIdxInfo->nConstraint; i++, pConstraint++){
+    if( pConstraint->usable==0 ) continue;
+    if( pConstraint->op!=SQLITE_INDEX_CONSTRAINT_EQ ) continue;
+    switch( pConstraint->iColumn ){
+      case CARRAY_COLUMN_POINTER:
+        ptrIdx = i;
+        break;
+      case CARRAY_COLUMN_COUNT:
+        cntIdx = i;
+        break;
+      case CARRAY_COLUMN_CTYPE:
+        ctypeIdx = i;
+        break;
+    }
+  }
+  if( ptrIdx>=0 ){
+    pIdxInfo->aConstraintUsage[ptrIdx].argvIndex = 1;
+    pIdxInfo->aConstraintUsage[ptrIdx].omit = 1;
+    pIdxInfo->estimatedCost = (double)1;
+    pIdxInfo->estimatedRows = 100;
+    pIdxInfo->idxNum = 1;
+    if( cntIdx>=0 ){
+      pIdxInfo->aConstraintUsage[cntIdx].argvIndex = 2;
+      pIdxInfo->aConstraintUsage[cntIdx].omit = 1;
+      pIdxInfo->idxNum = 2;
+      if( ctypeIdx>=0 ){
+        pIdxInfo->aConstraintUsage[ctypeIdx].argvIndex = 3;
+        pIdxInfo->aConstraintUsage[ctypeIdx].omit = 1;
+        pIdxInfo->idxNum = 3;
+      }
+    }
+  }else{
+    pIdxInfo->estimatedCost = (double)2147483647;
+    pIdxInfo->estimatedRows = 2147483647;
+    pIdxInfo->idxNum = 0;
+  }
+  return SQLITE_OK;
+}
+
+/*
+** This following structure defines all the methods for the 
+** carray virtual table.
+*/
+static sqlite3_module carrayModule = {
+  0,                         /* iVersion */
+  0,                         /* xCreate */
+  carrayConnect,             /* xConnect */
+  carrayBestIndex,           /* xBestIndex */
+  carrayDisconnect,          /* xDisconnect */
+  0,                         /* xDestroy */
+  carrayOpen,                /* xOpen - open a cursor */
+  carrayClose,               /* xClose - close a cursor */
+  carrayFilter,              /* xFilter - configure scan constraints */
+  carrayNext,                /* xNext - advance a cursor */
+  carrayEof,                 /* xEof - check for end of scan */
+  carrayColumn,              /* xColumn - read data */
+  carrayRowid,               /* xRowid - read data */
+  0,                         /* xUpdate */
+  0,                         /* xBegin */
+  0,                         /* xSync */
+  0,                         /* xCommit */
+  0,                         /* xRollback */
+  0,                         /* xFindMethod */
+  0,                         /* xRename */
+  0,                         /* xSavepoint */
+  0,                         /* xRelease */
+  0,                         /* xRollbackTo */
+  0,                         /* xShadow */
+  0                          /* xIntegrity */
+};
+
+/*
+** Destructor for the carray_bind object
+*/
+static void carrayBindDel(void *pPtr){
+  carray_bind *p = (carray_bind*)pPtr;
+  if( p->xDel!=SQLITE_STATIC ){
+     p->xDel(p->aData);
+  }
+  sqlite3_free(p);
+}
+
+/*
+** Invoke this interface in order to bind to the single-argument
+** version of CARRAY().
+*/
+SQLITE_API int sqlite3_carray_bind(
+  sqlite3_stmt *pStmt,
+  int idx,
+  void *aData,
+  int nData,
+  int mFlags,
+  void (*xDestroy)(void*)
+){
+  carray_bind *pNew;
+  int i;
+  pNew = sqlite3_malloc64(sizeof(*pNew));
+  if( pNew==0 ){
+    if( xDestroy!=SQLITE_STATIC && xDestroy!=SQLITE_TRANSIENT ){
+      xDestroy(aData);
+    }
+    return SQLITE_NOMEM;
+  }
+  pNew->nData = nData;
+  pNew->mFlags = mFlags;
+  if( xDestroy==SQLITE_TRANSIENT ){
+    sqlite3_int64 sz = nData;
+    switch( mFlags & 0x07 ){
+      case CARRAY_INT32:   sz *= 4;                     break;
+      case CARRAY_INT64:   sz *= 8;                     break;
+      case CARRAY_DOUBLE:  sz *= 8;                     break;
+      case CARRAY_TEXT:    sz *= sizeof(char*);         break;
+      case CARRAY_BLOB:    sz *= sizeof(struct iovec);  break;
+    }
+    if( (mFlags & 0x07)==CARRAY_TEXT ){
+      for(i=0; i<nData; i++){
+        const char *z = ((char**)aData)[i];
+        if( z ) sz += strlen(z) + 1;
+      }
+    }else if( (mFlags & 0x07)==CARRAY_BLOB ){
+      for(i=0; i<nData; i++){
+        sz += ((struct iovec*)aData)[i].iov_len;
+      }
+    } 
+    pNew->aData = sqlite3_malloc64( sz );
+    if( pNew->aData==0 ){
+      sqlite3_free(pNew);
+      return SQLITE_NOMEM;
+    }
+    if( (mFlags & 0x07)==CARRAY_TEXT ){
+      char **az = (char**)pNew->aData;
+      char *z = (char*)&az[nData];
+      for(i=0; i<nData; i++){
+        const char *zData = ((char**)aData)[i];
+        sqlite3_int64 n;
+        if( zData==0 ){
+          az[i] = 0;
+          continue;
+        }
+        az[i] = z;
+        n = strlen(zData);
+        memcpy(z, zData, n+1);
+        z += n+1;
+      }
+    }else if( (mFlags & 0x07)==CARRAY_BLOB ){
+      struct iovec *p = (struct iovec*)pNew->aData;
+      unsigned char *z = (unsigned char*)&p[nData];
+      for(i=0; i<nData; i++){
+        size_t n = ((struct iovec*)aData)[i].iov_len;
+        p[i].iov_len = n;
+        p[i].iov_base = z;
+        z += n;
+        memcpy(p[i].iov_base, ((struct iovec*)aData)[i].iov_base, n);
+      }
+    }else{
+      memcpy(pNew->aData, aData, sz);
+    }
+    pNew->xDel = sqlite3_free;
+  }else{
+    pNew->aData = aData;
+    pNew->xDel = xDestroy;
+  }
+  return sqlite3_bind_pointer(pStmt, idx, pNew, "carray-bind", carrayBindDel);
+}
+
+
+/*
+** For testing purpose in the TCL test harness, we need a method for
+** setting the pointer value.  The inttoptr(X) SQL function accomplishes
+** this.  Tcl script will bind an integer to X and the inttoptr() SQL
+** function will use sqlite3_result_pointer() to convert that integer into
+** a pointer.
+**
+** This is for testing on TCL only.
+*/
+#ifdef SQLITE_TEST
+static void inttoptrFunc(
+  sqlite3_context *context,
+  int argc,
+  sqlite3_value **argv
+){
+  void *p;
+  sqlite3_int64 i64;
+  i64 = sqlite3_value_int64(argv[0]);
+  if( sizeof(i64)==sizeof(p) ){
+    memcpy(&p, &i64, sizeof(p));
+  }else{
+    int i32 = i64 & 0xffffffff;
+    memcpy(&p, &i32, sizeof(p));
+  }
+  sqlite3_result_pointer(context, p, "carray", 0);
+}
+#endif /* SQLITE_TEST */
+
+#endif /* SQLITE_OMIT_VIRTUALTABLE */
+
+SQLITE_API int sqlite3_carray_init(
+  sqlite3 *db, 
+  char **pzErrMsg, 
+  const sqlite3_api_routines *pApi
+){
+  int rc = SQLITE_OK;
+
+  SQLITE_EXTENSION_INIT2(pApi);
+#ifndef SQLITE_OMIT_VIRTUALTABLE
+  rc = sqlite3_create_module(db, "carray", &carrayModule, 0);
+#ifdef SQLITE_TEST
+  if( rc==SQLITE_OK ){
+    rc = sqlite3_create_function(db, "inttoptr", 1, SQLITE_UTF8, 0,
+                                 inttoptrFunc, 0, 0);
+  }
+#endif /* SQLITE_TEST */
+#endif /* SQLITE_OMIT_VIRTUALTABLE */
+  return rc;
+}

--- a/lib/carray.h
+++ b/lib/carray.h
@@ -1,0 +1,50 @@
+/*
+** 2020-11-17
+**
+** The author disclaims copyright to this source code.  In place of
+** a legal notice, here is a blessing:
+**
+**    May you do good and not evil.
+**    May you find forgiveness for yourself and forgive others.
+**    May you share freely, never taking more than you give.
+**
+*************************************************************************
+**
+** Interface definitions for the CARRAY table-valued function
+** extension.
+*/
+
+#ifndef _CARRAY_H
+#define _CARRAY_H
+
+#include "sqlite3.h"              /* Required for error code definitions */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Use this interface to bind an array to the single-argument version
+** of CARRAY().
+*/
+SQLITE_API int sqlite3_carray_bind(
+  sqlite3_stmt *pStmt,        /* Statement to be bound */
+  int i,                      /* Parameter index */
+  void *aData,                /* Pointer to array data */
+  int nData,                  /* Number of data elements */
+  int mFlags,                 /* CARRAY flags */
+  void (*xDel)(void*)         /* Destructgor for aData*/
+);
+
+/* Allowed values for the mFlags parameter to sqlite3_carray_bind().
+*/
+#define CARRAY_INT32     0    /* Data is 32-bit signed integers */
+#define CARRAY_INT64     1    /* Data is 64-bit signed integers */
+#define CARRAY_DOUBLE    2    /* Data is doubles */
+#define CARRAY_TEXT      3    /* Data is char* */
+#define CARRAY_BLOB      4    /* Data is struct iovec */
+
+#ifdef __cplusplus
+}  /* end of the 'extern "C"' block */
+#endif
+
+#endif /* ifndef _CARRAY_H */

--- a/lib/dune
+++ b/lib/dune
@@ -2,9 +2,10 @@
  (public_name sqlite3)
  (foreign_stubs
   (language c)
-  (names sqlite3_stubs)
+  (names sqlite3_stubs carray)
   (flags
    (:standard)
+   (-DSQLITE_CORE) (-I.)
    (:include c_flags.sexp)))
  (c_library_flags
   (:include c_library_flags.sexp)))

--- a/lib/sqlite3.ml
+++ b/lib/sqlite3.ml
@@ -232,6 +232,15 @@ module Data = struct
     | TEXT t | BLOB t -> t
 end
 
+module CArray = struct
+  type int64_c_array =
+    (Int64.t, Bigarray.int64_elt, Bigarray.c_layout) Bigarray.Array1.t
+
+  type t = Int64 of int64_c_array
+
+  let of_int64_bigarray int64_c_array = Int64 int64_c_array
+end
+
 type header = string
 type headers = header array
 type row = string option array
@@ -386,6 +395,9 @@ external bind_parameter_index : stmt -> string -> (int[@untagged])
 
 external bind_blob : stmt -> (int[@untagged]) -> string -> Rc.t
   = "caml_sqlite3_bind_blob_bc" "caml_sqlite3_bind_blob"
+
+external bind_carray : stmt -> (int[@untagged]) -> CArray.t -> Rc.t
+  = "caml_sqlite3_bind_blob_bc" "caml_sqlite3_bind_carray"
 
 external bind_double : stmt -> (int[@untagged]) -> (float[@unboxed]) -> Rc.t
   = "caml_sqlite3_bind_double_bc" "caml_sqlite3_bind_double"

--- a/lib/sqlite3.mli
+++ b/lib/sqlite3.mli
@@ -279,6 +279,13 @@ module Data : sig
       Useful for debugging. *)
 end
 
+module CArray : sig
+  type t
+
+  val of_int64_bigarray :
+    (Int64.t, Bigarray.int64_elt, Bigarray.c_layout) Bigarray.Array1.t -> t
+end
+
 (** {2 General database operations} *)
 
 val db_open :
@@ -678,6 +685,15 @@ val bind_double : stmt -> int -> float -> Rc.t
 val bind_blob : stmt -> int -> string -> Rc.t
 (** [bind_blob stmt pos str] binds the string [str] to the parameter at position
     [pos] of the statement [stmt] as a blob.
+
+    @return the return code of this operation.
+
+    @raise RangeError if [pos] is out of range.
+    @raise SqliteError if the statement is invalid. *)
+
+val bind_carray : stmt -> int -> CArray.t -> Rc.t
+(** [bind_carray stmt pos carray] binds the carray [carray] to the parameter at
+    position [pos] of the statement [stmt] as a blob.
 
     @return the return code of this operation.
 

--- a/lib/sqlite3_stubs.c
+++ b/lib/sqlite3_stubs.c
@@ -876,6 +876,7 @@ static inline void free_stmt_carrays(stmt_wrap *stmtw) {
     caml_stat_free(bound_carrays);
     bound_carrays = next;
   }
+  stmtw->carrays = NULL;
 }
 
 static inline void stmt_wrap_finalize_gc(value v_stmt) {

--- a/lib/sqlite3_stubs.c
+++ b/lib/sqlite3_stubs.c
@@ -1034,9 +1034,9 @@ CAMLprim value caml_sqlite3_bind_blob(value v_stmt, intnat pos, value v_str) {
 }
 
 
-static void bind_carray(stmt_wrap* stmtw, intnat pos, value int_array_variant) {
+static void bind_carray(stmt_wrap* stmtw, intnat pos, value array) {
   carray *new_carray = caml_stat_alloc(sizeof(carray));
-  new_carray->the_array = int_array_variant;
+  new_carray->the_array = array;
   caml_register_global_root(&new_carray->the_array);
   new_carray->pos = pos;
   new_carray->next = stmtw->carrays;
@@ -1055,9 +1055,9 @@ CAMLprim value caml_sqlite3_bind_carray(value v_stmt, intnat pos, value int_arra
   range_check(pos - 1, sqlite3_bind_parameter_count(stmt));
 
   // get the actual array
-  value int_array = Field(int_array_variant, 0);
+  value int_array = Field(int_array_variant, 0); // TODO: support other types
 
-  // store the carray variable (TODO: remove the previous bound value)
+  // store the carray variable
   free_stmt_carray_at_pos(stmtw, pos);
   bind_carray(stmtw, pos, int_array);
 

--- a/lib/sqlite3_stubs.c
+++ b/lib/sqlite3_stubs.c
@@ -1025,8 +1025,10 @@ CAMLprim value caml_sqlite3_bind_parameter_index_bc(value v_stmt,
 /* bind_blob */
 
 CAMLprim value caml_sqlite3_bind_blob(value v_stmt, intnat pos, value v_str) {
-  sqlite3_stmt *stmt = safe_get_stmtw("bind_blob", v_stmt)->stmt;
+  stmt_wrap *stmtw = safe_get_stmtw("bind_blob", v_stmt);
+  sqlite3_stmt *stmt = stmtw->stmt;
   range_check(pos - 1, sqlite3_bind_parameter_count(stmt));
+  free_stmt_carray_at_pos(stmtw, pos);
   return Val_rc(sqlite3_bind_blob(stmt, pos, String_val(v_str),
                                   caml_string_length(v_str), SQLITE_TRANSIENT));
 }
@@ -1074,8 +1076,10 @@ CAMLprim value caml_sqlite3_bind_blob_bc(value v_stmt, value v_pos,
 /* bind_double */
 
 CAMLprim value caml_sqlite3_bind_double(value v_stmt, intnat pos, double n) {
-  sqlite3_stmt *stmt = safe_get_stmtw("bind_double", v_stmt)->stmt;
+  stmt_wrap *stmtw = safe_get_stmtw("bind_double", v_stmt);
+  sqlite3_stmt *stmt = stmtw->stmt;
   range_check(pos - 1, sqlite3_bind_parameter_count(stmt));
+  free_stmt_carray_at_pos(stmtw, pos);
   return Val_rc(sqlite3_bind_double(stmt, pos, n));
 }
 
@@ -1087,8 +1091,10 @@ CAMLprim value caml_sqlite3_bind_double_bc(value v_stmt, value v_pos,
 /* bind_int32 */
 
 CAMLprim value caml_sqlite3_bind_int32(value v_stmt, intnat pos, int32_t n) {
-  sqlite3_stmt *stmt = safe_get_stmtw("bind_int32", v_stmt)->stmt;
+  stmt_wrap *stmtw = safe_get_stmtw("bind_int32", v_stmt);
+  sqlite3_stmt *stmt = stmtw->stmt;
   range_check(pos - 1, sqlite3_bind_parameter_count(stmt));
+  free_stmt_carray_at_pos(stmtw, pos);
   return Val_rc(sqlite3_bind_int(stmt, pos, n));
 }
 
@@ -1100,8 +1106,10 @@ CAMLprim value caml_sqlite3_bind_int32_bc(value v_stmt, value v_pos,
 /* bind_int64 */
 
 CAMLprim value caml_sqlite3_bind_int64(value v_stmt, intnat pos, int64_t n) {
-  sqlite3_stmt *stmt = safe_get_stmtw("bind_int64", v_stmt)->stmt;
+  stmt_wrap *stmtw = safe_get_stmtw("bind_int64", v_stmt);
+  sqlite3_stmt *stmt = stmtw->stmt;
   range_check(pos - 1, sqlite3_bind_parameter_count(stmt));
+  free_stmt_carray_at_pos(stmtw, pos);
   return Val_rc(sqlite3_bind_int64(stmt, pos, n));
 }
 
@@ -1113,8 +1121,10 @@ CAMLprim value caml_sqlite3_bind_int64_bc(value v_stmt, value v_pos,
 /* bind_text */
 
 CAMLprim value caml_sqlite3_bind_text(value v_stmt, intnat pos, value v_str) {
-  sqlite3_stmt *stmt = safe_get_stmtw("bind_text", v_stmt)->stmt;
+  stmt_wrap *stmtw = safe_get_stmtw("bind_text", v_stmt);
+  sqlite3_stmt *stmt = stmtw->stmt;
   range_check(pos - 1, sqlite3_bind_parameter_count(stmt));
+  free_stmt_carray_at_pos(stmtw, pos);
   return Val_rc(sqlite3_bind_text(stmt, pos, String_val(v_str),
                                   caml_string_length(v_str), SQLITE_TRANSIENT));
 }
@@ -1127,8 +1137,10 @@ CAMLprim value caml_sqlite3_bind_text_bc(value v_stmt, value v_pos,
 /* bind */
 
 CAMLprim value caml_sqlite3_bind(value v_stmt, intnat pos, value v_data) {
-  sqlite3_stmt *stmt = safe_get_stmtw("bind", v_stmt)->stmt;
+  stmt_wrap *stmtw = safe_get_stmtw("bind", v_stmt);
+  sqlite3_stmt *stmt = stmtw->stmt;
   range_check(pos - 1, sqlite3_bind_parameter_count(stmt));
+  free_stmt_carray_at_pos(stmtw, pos);
   if (Is_long(v_data)) {
     switch (Int_val(v_data)) {
     case 1:
@@ -1163,7 +1175,9 @@ CAMLprim value caml_sqlite3_bind_bc(value v_stmt, value v_pos, value v_data) {
 /* clear_bindings */
 
 CAMLprim value caml_sqlite3_clear_bindings(value v_stmt) {
-  sqlite3_stmt *stmt = safe_get_stmtw("clear_bindings", v_stmt)->stmt;
+  stmt_wrap *stmtw = safe_get_stmtw("clear_bindings", v_stmt);
+  sqlite3_stmt *stmt = stmtw->stmt;
+  free_stmt_carrays(stmtw);
   return Val_rc(sqlite3_clear_bindings(stmt));
 }
 

--- a/lib/sqlite3_stubs.c
+++ b/lib/sqlite3_stubs.c
@@ -28,7 +28,6 @@
 #include <string.h>
 
 #include <stdatomic.h>
-#include <inttypes.h>
 
 #include <caml/alloc.h>
 #include <caml/bigarray.h>

--- a/test/test_carrays.ml
+++ b/test/test_carrays.ml
@@ -1,0 +1,78 @@
+open Sqlite3
+
+let get_all stmt : Data.t array list =
+  let f acc row = row :: acc in
+  let rc, rows = fold stmt ~f ~init:[] in
+  assert (rc = Rc.DONE);
+  List.rev rows
+
+let compare_data (lhs : Data.t) (rhs : Data.t) : int =
+  let open Data in
+  match (lhs, rhs) with
+  | NONE, NONE -> 0
+  | NULL, NULL -> 0
+  | INT x, INT y -> Int64.compare x y
+  | FLOAT x, FLOAT y -> Float.compare x y
+  | TEXT x, TEXT y -> String.compare x y
+  | BLOB x, BLOB y -> String.compare x y
+  | _ -> 1
+
+let compare_query_row (lhs : Data.t array) (rhs : Data.t array) =
+  let lhs = Array.to_seq lhs in
+  let rhs = Array.to_seq rhs in
+  Seq.compare compare_data lhs rhs
+
+let%test "can_get_int64_values_out_of_carray" =
+  let db = db_open ":memory:" in
+
+  let carray =
+    Bigarray.(Array1.of_array int64 c_layout [| 1L; 2L; 10L; 11L; 30L |])
+    |> CArray.of_int64_bigarray
+  in
+  let stmt = prepare db "SELECT value FROM carray($ptr)" in
+  assert (Rc.OK = bind_carray stmt 1 carray);
+  let expected : Data.t array list =
+    [ [| INT 1L |]; [| INT 2L |]; [| INT 10L |]; [| INT 11L |]; [| INT 30L |] ]
+  in
+  assert (0 = List.compare compare_query_row (get_all stmt) expected);
+  true
+
+let%test "carray_lifetime_is_bound_to_stmt" =
+  let db = db_open ":memory:" in
+
+  let stmt =
+    let carray =
+      Bigarray.(Array1.of_array int64 c_layout [| 1L; 2L; 10L; 11L; 30L |])
+      |> CArray.of_int64_bigarray
+    in
+    let stmt = prepare db "SELECT value FROM carray($ptr)" in
+    assert (Rc.OK = bind_carray stmt 1 carray);
+    stmt
+  in
+  Gc.full_major ();
+  let expected : Data.t array list =
+    [ [| INT 1L |]; [| INT 2L |]; [| INT 10L |]; [| INT 11L |]; [| INT 30L |] ]
+  in
+  assert (0 = List.compare compare_query_row (get_all stmt) expected);
+  true
+
+let make_carray size =
+  let ba = Bigarray.(Array1.create int64 c_layout size) in
+  CArray.of_int64_bigarray ba
+
+let%test "memory_for_bigarray_is_released_when_finalizing_statement" =
+  let db = db_open ":memory:" in
+  let was_array_collected, stmt =
+    let ba = Bigarray.(Array1.create int64 c_layout 10) in
+    let was_array_collected = ref false in
+    Gc.finalise_last (fun () -> was_array_collected := true) ba;
+    let stmt = prepare db "SELECT value FROM carray($ptr)" in
+    assert (Rc.OK = bind_carray stmt 1 (CArray.of_int64_bigarray ba));
+    (was_array_collected, stmt)
+  in
+  Gc.full_major ();
+  assert (not !was_array_collected);
+  Rc.check (finalize stmt);
+  Gc.full_major ();
+  assert !was_array_collected;
+  true

--- a/test/test_carrays.ml
+++ b/test/test_carrays.ml
@@ -56,23 +56,100 @@ let%test "carray_lifetime_is_bound_to_stmt" =
   assert (0 = List.compare compare_query_row (get_all stmt) expected);
   true
 
-let make_carray size =
-  let ba = Bigarray.(Array1.create int64 c_layout size) in
-  CArray.of_int64_bigarray ba
+let make_bigarray size = Bigarray.(Array1.create int64 c_layout size)
+
+let evaluate_if_collected obj =
+  let was_collected = ref false in
+  Gc.finalise_last (fun _ -> was_collected := true) obj;
+  was_collected
 
 let%test "memory_for_bigarray_is_released_when_finalizing_statement" =
   let db = db_open ":memory:" in
   let was_array_collected, stmt =
-    let ba = Bigarray.(Array1.create int64 c_layout 10) in
-    let was_array_collected = ref false in
-    Gc.finalise_last (fun () -> was_array_collected := true) ba;
+    let ba = make_bigarray 10 in
+    let was_array_collected = evaluate_if_collected ba in
     let stmt = prepare db "SELECT value FROM carray($ptr)" in
     assert (Rc.OK = bind_carray stmt 1 (CArray.of_int64_bigarray ba));
     (was_array_collected, stmt)
   in
+
+  (* at first, the bigarray is not collected because it's bound to the
+     statement *)
   Gc.full_major ();
   assert (not !was_array_collected);
+
+  (* but after finalizing the statement *)
   Rc.check (finalize stmt);
+
+  (* the array can get collected *)
   Gc.full_major ();
   assert !was_array_collected;
+  true
+
+let%test "rebinding carray makes previously-bound carray collectable" =
+  let db = db_open ":memory:" in
+  let was_array_collected, stmt =
+    let ba = make_bigarray 10 in
+    let was_array_collected = evaluate_if_collected ba in
+    let stmt = prepare db "SELECT value FROM carray($ptr)" in
+    assert (Rc.OK = bind_carray stmt 1 (CArray.of_int64_bigarray ba));
+    (was_array_collected, stmt)
+  in
+  (* at first, the bigarray is not collected because it's bound to the
+     statement *)
+  Gc.full_major ();
+  assert (not !was_array_collected);
+
+  (* but then we bind a different carray to the same position in the
+     statement *)
+  let new_carray = make_bigarray 10 |> CArray.of_int64_bigarray in
+  assert (Rc.OK = bind_carray stmt 1 new_carray);
+
+  (* and then the array does get collected *)
+  Gc.full_major ();
+  assert !was_array_collected;
+  true
+
+let make_sql_query_with_n_carrays n =
+  let carray_part = List.init n (fun i -> "carray(?) as c" ^ string_of_int i) in
+  "SELECT * FROM " ^ String.concat ", " carray_part
+
+let%test "rebinding_clears_only_one_of_the_bigarrays" =
+  let n = 3 in
+  let db = db_open ":memory:" in
+  let collections, stmt =
+    let arrays = List.init n (fun _ -> make_bigarray 10) in
+    let collections = List.map evaluate_if_collected arrays in
+    let stmt = prepare db (make_sql_query_with_n_carrays n) in
+    List.iteri
+      (fun i array ->
+        assert (
+          Rc.OK = bind_carray stmt (i + 1) (CArray.of_int64_bigarray array)))
+      arrays;
+    (collections, stmt)
+  in
+
+  (* at first, no carray gets collected (they are all bound to the statement) *)
+  Gc.full_major ();
+  assert (List.for_all (fun was_collected -> not !was_collected) collections);
+
+  (* when we rebind parameter 1 *)
+  assert (
+    Rc.OK = bind_carray stmt 1 (CArray.of_int64_bigarray (make_bigarray 10)));
+
+  (* only that one gets collected *)
+  Gc.full_major ();
+  assert !(List.nth collections 0);
+  assert (not !(List.nth collections 1));
+  assert (not !(List.nth collections 2));
+
+  (* when we rebind parameter 3 *)
+  assert (
+    Rc.OK = bind_carray stmt 3 (CArray.of_int64_bigarray (make_bigarray 10)));
+
+  (* that one gets collected too *)
+  Gc.full_major ();
+  assert !(List.nth collections 2);
+  assert (not !(List.nth collections 1));
+
   true


### PR DESCRIPTION
Fixes #60 

The PR still requires more work (and even after that work, we may decide it's not worth merging). Just sharing what I have because, from the issue:

> This is one of those things that are hard to judge before there is a proposed implementation. 

I think what I have already shows what the final design would be like, even if it's missing important things like:

- Supporting carrays with types different from int64
- Error handling (when initializing the extension)
- Packaging 
- General polish
